### PR TITLE
Good bye failure, Hello anyhow/thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,34 +55,9 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "backtrace"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "base64"
-version = "0.10.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "bincode"
@@ -168,26 +148,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -344,11 +304,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "plist"
-version = "0.5.5"
+name = "onig"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "onig_sys 69.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "plist"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "line-wrap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -382,10 +367,10 @@ name = "refmt"
 version = "0.2.2"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -393,7 +378,8 @@ dependencies = [
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntect 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntect 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -416,11 +402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ryu"
@@ -452,7 +433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -495,33 +476,22 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syntect"
-version = "4.1.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -530,7 +500,8 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "plist 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "onig 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plist 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -564,6 +535,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -691,12 +680,11 @@ dependencies = [
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+"checksum anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
-"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
-"checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum base64 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e223af0dc48c96d4f8342ec01a4974f139df863896b316681efd36742f22cc67"
 "checksum bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
@@ -709,8 +697,6 @@ dependencies = [
 "checksum crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-"checksum failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-"checksum failure_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 "checksum flate2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2291c165c8e703ee54ef3055ad6188e3d51108e2ded18e9f2476e774fc5ad3d4"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
@@ -731,13 +717,15 @@ dependencies = [
 "checksum miniz_oxide_c_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28edaef377517fd9fe3e085c37d892ce7acd1fbeab9239c5a36eec352d8a8b7e"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
-"checksum plist 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9b59eb8d91dfa89208ec74a920e3b55f840476cf46568026c18dbaa2999e0d48"
+"checksum onig 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd91ccd8a02fce2f7e8a86655aec67bc6c171e6f8e704118a0e8c4b866a05a8a"
+"checksum onig_sys 69.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3814583fad89f3c60ae0701d80e87e1fd3028741723deda72d0d4a0ecf0cb0db"
+"checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+"checksum plist 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b336d94e8e4ce29bf15bba393164629764744c567e8ad306cc1fdd0119967fd"
 "checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
-"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
@@ -748,12 +736,13 @@ dependencies = [
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum strum 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
 "checksum strum_macros 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
-"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
-"checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
-"checksum syntect 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6bc79276a4d38e39fbeb83c5fd9c23fbd027eeec7c50ee6a3d07deee33d7f621"
+"checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
+"checksum syntect 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83b43a6ca1829ccb0c933b615c9ea83ffc8793ae240cecbd15119b13d741161d"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+"checksum thiserror-impl 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,15 @@ path = "src/bin/generate_assets/main.rs"
 
 [dependencies]
 ansi_term = "0.12"
+anyhow = "1"
 atty = "0.2"
 env_logger = "0.7"
-failure = "0.1"
 log = "0.4"
 serde = "1.0"
 serde_yaml = "0.8"
 strum = "0.18"
 strum_macros = "0.18"
+thiserror = "1"
 toml = "0.5"
 
 [dependencies.clap ]
@@ -36,9 +37,9 @@ version = "1.0"
 features = ["preserve_order"]
 
 [dependencies.syntect]
-version = "4.1"
+version = "4.2"
 default_features = false
-features = ["parsing", "yaml-load", "dump-load", "dump-create"]
+features = ["parsing", "yaml-load", "dump-load", "dump-create", "regex-onig"]
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/src/bin/refmt/main.rs
+++ b/src/bin/refmt/main.rs
@@ -1,7 +1,5 @@
 use std::process;
 
-use failure::Fail;
-
 use refmt::errors;
 
 mod app;
@@ -10,11 +8,7 @@ mod printer;
 fn handle_error(error: &errors::Error) {
     use ansi_term::Color::Red;
     let label = Red.paint("[refmt error]");
-    if let Some(cause) = error.cause() {
-        eprintln!("{}: {}. cause: {}", label, error, cause);
-    } else {
-        eprintln!("{}: {}.", label, error);
-    }
+    eprintln!("{}: {}.", label, error);
 }
 
 fn initialize() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,65 +1,24 @@
-use std::fmt::{self, Display, Formatter};
+use std::io;
 
-use failure::{Backtrace, Context, Fail};
+use thiserror::Error;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Fail)]
-pub enum ErrorKind {
-    #[fail(display = "IO Error")]
-    Io,
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("IO Error. cause:{_0}")]
+    Io(#[from] io::Error),
 
-    #[fail(display = "Any errors occurred during serialization")]
-    Serialization,
+    #[error("Any errors occurred during serialization")]
+    Serialization(String),
 
-    #[fail(display = "Any errors occurred during deserialization")]
-    Deserialization,
+    #[error("Any errors occurred during deserialization")]
+    Deserialization(String),
 
-    #[fail(display = "Unsupported format name")]
-    FormatName,
+    #[error("Unsupported format name. name:{_0}")]
+    FormatName(String),
 
-    #[fail(display = "Cannot infer format. Please specify either FILE or FORMAT")]
+    #[error("Cannot infer format. Please specify either FILE or FORMAT")]
     InferFormat,
 
-    #[fail(display = "Cannot create assets")]
-    CreatingAssets,
-}
-
-#[derive(Debug)]
-pub struct Error {
-    inner: Context<ErrorKind>,
-}
-
-impl Error {
-    pub fn kind(&self) -> ErrorKind {
-        *self.inner.get_context()
-    }
-}
-
-impl Fail for Error {
-    fn cause(&self) -> Option<&Fail> {
-        self.inner.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        Display::fmt(&self.inner, f)
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Self {
-        Error {
-            inner: Context::new(kind),
-        }
-    }
-}
-
-impl From<Context<ErrorKind>> for Error {
-    fn from(context: Context<ErrorKind>) -> Self {
-        Error { inner: context }
-    }
+    #[error("Cannot create assets")]
+    CreatingAssets(String),
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -135,15 +135,6 @@ author:
 
         let r = Format::from_str("conf"); // HOCON
         assert!(r.is_err());
-        assert_eq!(errors::ErrorKind::FormatName, r.err().unwrap().kind());
-
-        let r = Format::from_str("ini");
-        assert!(r.is_err());
-        assert_eq!(errors::ErrorKind::FormatName, r.err().unwrap().kind());
-
-        let r = Format::from_str("xml");
-        assert!(r.is_err());
-        assert_eq!(errors::ErrorKind::FormatName, r.err().unwrap().kind());
     }
 
     #[test]
@@ -174,7 +165,6 @@ last_name = "Doe"
         let text = FormattedText::new(Format::Json, YAML_TEXT.to_string());
         let r = text.convert_to(Format::Toml);
         assert!(r.is_err());
-        assert_eq!(errors::ErrorKind::Deserialization, r.err().unwrap().kind());
     }
 
     #[test]
@@ -206,7 +196,6 @@ last_name = "Doe"
         let text = FormattedText::new(Format::Toml, JSON_TEXT.to_string());
         let r = text.convert_to(Format::Yaml);
         assert!(r.is_err());
-        assert_eq!(errors::ErrorKind::Deserialization, r.err().unwrap().kind());
     }
 
     #[test]

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,6 +1,5 @@
 use std::str::FromStr;
 
-use failure::{Fail, ResultExt};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
@@ -9,12 +8,6 @@ use crate::errors;
 mod json;
 mod toml;
 mod yaml;
-
-#[derive(Fail, Debug)]
-#[fail(display = "Unsupported format: {}", name)]
-struct UnsupportedFormatError {
-    name: String,
-}
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, EnumIter)]
 pub enum Format {
@@ -60,10 +53,7 @@ impl FromStr for Format {
         let lower = s.to_ascii_lowercase();
         Ok(Format::iter()
             .find(|f| f.is_extension(&lower))
-            .ok_or(UnsupportedFormatError {
-                name: s.to_string(),
-            })
-            .context(errors::ErrorKind::FormatName)?)
+            .ok_or(errors::Error::FormatName(s.to_string()))?)
     }
 }
 

--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -1,20 +1,23 @@
-use failure::ResultExt;
 use serde::de;
 use serde::ser;
 
-use crate::errors::{self, ErrorKind};
+use crate::errors;
 
 pub use serde_json::Value as InnerValue;
 
 pub fn serialize<V: ser::Serialize>(v: V) -> Result<String, errors::Error> {
-    Ok(serde_json::to_string_pretty(&v).context(ErrorKind::Serialization)?)
+    let json = serde_json::to_string_pretty(&v)
+        .map_err(|e| errors::Error::Serialization(e.to_string()))?;
+    Ok(json)
 }
 
 pub fn deserialize<V>(s: &str) -> Result<V, errors::Error>
 where
     V: for<'de> de::Deserialize<'de>,
 {
-    Ok(serde_json::from_str(s).context(ErrorKind::Deserialization)?)
+    let data =
+        serde_json::from_str(s).map_err(|e| errors::Error::Deserialization(e.to_string()))?;
+    Ok(data)
 }
 
 #[cfg(test)]

--- a/src/format/toml.rs
+++ b/src/format/toml.rs
@@ -1,20 +1,21 @@
-use failure::ResultExt;
 use serde::de;
 use serde::ser;
 
-use crate::errors::{self, ErrorKind};
+use crate::errors;
 
 pub use toml::Value as InnerValue;
 
 pub fn serialize<V: ser::Serialize>(v: V) -> Result<String, errors::Error> {
-    Ok(toml::to_string(&v).context(ErrorKind::Serialization)?)
+    let toml = toml::to_string(&v).map_err(|e| errors::Error::Serialization(e.to_string()))?;
+    Ok(toml)
 }
 
 pub fn deserialize<V>(s: &str) -> Result<V, errors::Error>
 where
     V: for<'de> de::Deserialize<'de>,
 {
-    Ok(toml::from_str(s).context(ErrorKind::Deserialization)?)
+    let data = toml::from_str(s).map_err(|e| errors::Error::Deserialization(e.to_string()))?;
+    Ok(data)
 }
 
 #[cfg(test)]

--- a/src/format/yaml.rs
+++ b/src/format/yaml.rs
@@ -1,20 +1,23 @@
-use failure::ResultExt;
 use serde::de;
 use serde::ser;
 
-use crate::errors::{self, ErrorKind};
+use crate::errors;
 
 pub use serde_yaml::Value as InnerValue;
 
 pub fn serialize<V: ser::Serialize>(v: V) -> Result<String, errors::Error> {
-    Ok(serde_yaml::to_string(&v).context(ErrorKind::Serialization)?)
+    let yaml =
+        serde_yaml::to_string(&v).map_err(|e| errors::Error::Serialization(format!("{:?}", e)))?;
+    Ok(yaml)
 }
 
 pub fn deserialize<V>(s: &str) -> Result<V, errors::Error>
 where
     V: for<'de> de::Deserialize<'de>,
 {
-    Ok(serde_yaml::from_str(s).context(ErrorKind::Deserialization)?)
+    let data =
+        serde_yaml::from_str(s).map_err(|e| errors::Error::Deserialization(format!("{:?}", e)))?;
+    Ok(data)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Remove `failure` from dependency
- Add `anyhow` and `thiserror` as dependencies
- Simplify format inference
- Remove redundant tests